### PR TITLE
Chore | Add Codowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # These owners will be the default owners for everything in the repo.
 *    @EstebanBorai
-
+*    @morenol 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Understand this file here: https://github.blog/2017-07-06-introducing-code-owners/#how-code-owners-work
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*    @EstebanBorai
+


### PR DESCRIPTION
As we are just 3 - 4 collaborators working on this project at the moment
awaiting on 2 reviews for merging is turning a bit of a blocker.

In order to keep moving on perhaps defining code owners while we grow
is a good idea, so all PRs are reviewed by more active members instead of
waiting for 2 code reviewers. (we usually have just one).

To keep the structure of the project and provide the most of the feedback
before officially merging a PR I think that its important to keep PR reviews from
at least 1 collaborator.

Suggestions on **this or other** approach would be awesome I think is important
to avoid the [BDFL](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) kind model and move forward to a _open governance_.

If you want to be a code owner just edit the CODEOWNERS file but keep in mind that
your review will be required in future PRs!

<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/rust-lang-ve/rust-lang-ve.github.io/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
